### PR TITLE
Update for next version on master (from v1.0.1 to v1.0.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>resumable.js</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>Resumable.js</name>
     <description>WebJar for Resumable.js</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1.0</upstream.version>
+        <upstream.version>1.0.2</upstream.version>
         <upstream.url>https://github.com/23/resumable.js/archive/</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
@@ -48,7 +48,7 @@
         <url>http://github.com/webjars/resumable.js</url>
         <connection>scm:git:https://github.com/webjars/resumable.js.git</connection>
         <developerConnection>scm:git:https://github.com/webjars/resumable.js.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.0.2</tag>
     </scm>
     
     <dependencies>


### PR DESCRIPTION
There is a more current version [v1.0.2](https://github.com/23/resumable.js/releases/tag/v1.0.2) tagged on the repository [23/resumable.js](https://github.com/23/resumable.js).

I hope that this PR introduces the necessary changes to release the new version.

**Sidenote:** the step from v1.0.1 to v1.0.2 introduces braking changes.