### PR TITLE
Bump upstream version 1.0.2 -> 1.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1.0.2</upstream.version>
+        <upstream.version>1.0.3</upstream.version>
         <upstream.url>https://github.com/23/resumable.js/archive/</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
@@ -48,7 +48,7 @@
         <url>http://github.com/webjars/resumable.js</url>
         <connection>scm:git:https://github.com/webjars/resumable.js.git</connection>
         <developerConnection>scm:git:https://github.com/webjars/resumable.js.git</developerConnection>
-        <tag>v1.0.2</tag>
+        <tag>v1.0.3</tag>
     </scm>
     
     <dependencies>


### PR DESCRIPTION
The new version of resumable.js is now tagged on upstream (after https://github.com/23/resumable.js/issues/328#issuecomment-304596866).

@jamesward  could you please merge this PR and release the new version?